### PR TITLE
correcting origin in plot (within base.py) from "bottomleft" to "lower"

### DIFF
--- a/tftb/processing/base.py
+++ b/tftb/processing/base.py
@@ -79,7 +79,7 @@ class BaseTFRepresentation(object):
     def _plot_tfr(self, ax, kind, extent, contour_x=None, contour_y=None,
                   levels=None, show_tf=True, cmap=plt.cm.gray):
         if kind == "cmap":
-            ax.imshow(self.tfr, cmap=cmap, origin="bottomleft", extent=extent,
+            ax.imshow(self.tfr, cmap=cmap, origin="lower", extent=extent,
                       aspect='auto')
         elif kind == "contour":
             if contour_x is None:
@@ -202,7 +202,7 @@ class BaseTFRepresentation(object):
                 ax = fig.add_subplot(111)
             if kind == "cmap":
                 ax.imshow(self.tfr,
-                          aspect='auto', origin='bottomleft', extent=extent,
+                          aspect='auto', cmap=cmap, origin='lower', extent=extent,
                           **kwargs)
             elif kind == "surf":
                 from mpl_toolkits.mplot3d import Axes3D


### PR DESCRIPTION
correcting origin of the plot in the plot function within processing/base.py from "bottomleft" to "lower"