### PR TITLE
Update deprecated scipy function names and import, and fix variables type errors

### DIFF
--- a/tftb/generators/utils.py
+++ b/tftb/generators/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.signal import hilbert
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 # from tftb.utils import nextpow2
 
 
@@ -82,7 +82,7 @@ def scale(X, a, fmin, fmax, N):
                                                  geo_f.reshape((1, 128))))
         dilate_sig = np.zeros((2 * Mcurrent,), dtype=complex)
         for kk in range(2 * int(Mcurrent)):
-            dilate_sig[kk] = trapz(itfmatx[kk, :] * DS[:N], geo_f)
+            dilate_sig[kk] = trapezoid(itfmatx[kk, :] * DS[:N], geo_f)
         S[(Mmax - Mcurrent):(Mmax + Mcurrent)] = dilate_sig
         ptr += 1
 

--- a/tftb/processing/base.py
+++ b/tftb/processing/base.py
@@ -11,7 +11,7 @@ Base time-frequency representation class.
 """
 
 import numpy as np
-from scipy.signal import hamming
+from scipy.signal.windows import hamming
 import matplotlib.pyplot as plt
 
 

--- a/tftb/processing/cohen.py
+++ b/tftb/processing/cohen.py
@@ -72,7 +72,7 @@ class PseudoPageRepresentation(PageRepresentation):
     name = "pseudo page"
 
     def _make_window(self):
-        hlength = np.floor(self.n_fbins / 4.0)
+        hlength = int(np.floor(self.n_fbins / 4.0))
         if hlength % 2 == 0:
             hlength += 1
         from scipy.signal.windows import hamming
@@ -122,16 +122,16 @@ class PseudoMargenauHillDistribution(MargenauHillDistribution):
     name = "pseudo margenau-hill"
 
     def _make_window(self):
-        hlength = np.floor(self.n_fbins / 4.0)
+        hlength = int(np.floor(self.n_fbins / 4.0))
         if hlength % 2 == 0:
             hlength += 1
         from scipy.signal.windows import hamming
         fwindow = hamming(hlength)
-        lh = (fwindow.shape[0] - 1) / 2
+        lh = (fwindow.shape[0] - 1) // 2
         return fwindow / fwindow[lh]
 
     def run(self):
-        lh = (self.fwindow.shape[0] - 1) / 2
+        lh = (self.fwindow.shape[0] - 1) // 2
         xrow = self.signal.shape[0]
         for icol in range(self.ts.shape[0]):
             start = min([np.round(self.n_fbins / 2.0) - 1, lh, xrow - icol])

--- a/tftb/processing/cohen.py
+++ b/tftb/processing/cohen.py
@@ -75,7 +75,7 @@ class PseudoPageRepresentation(PageRepresentation):
         hlength = np.floor(self.n_fbins / 4.0)
         if hlength % 2 == 0:
             hlength += 1
-        from scipy.signal import hamming
+        from scipy.signal.windows import hamming
         fwindow = hamming(hlength)
         lh = (fwindow.shape[0] - 1) / 2
         return fwindow / fwindow[lh]
@@ -125,7 +125,7 @@ class PseudoMargenauHillDistribution(MargenauHillDistribution):
         hlength = np.floor(self.n_fbins / 4.0)
         if hlength % 2 == 0:
             hlength += 1
-        from scipy.signal import hamming
+        from scipy.signal.windows import hamming
         fwindow = hamming(hlength)
         lh = (fwindow.shape[0] - 1) / 2
         return fwindow / fwindow[lh]
@@ -242,7 +242,7 @@ def smoothed_pseudo_wigner_ville(signal, timestamps=None, freq_bins=None,
     if fwindow is None:
         winlength = freq_bins // 4
         winlength = winlength + 1 - (winlength % 2)
-        from scipy.signal import hamming
+        from scipy.signal.windows import hamming
         fwindow = hamming(int(winlength))
     elif fwindow.shape[0] % 2 == 0:
         raise ValueError('The smoothing fwindow must have an odd length.')
@@ -250,7 +250,7 @@ def smoothed_pseudo_wigner_ville(signal, timestamps=None, freq_bins=None,
     if twindow is None:
         timelength = freq_bins // 10
         timelength += 1 - (timelength % 2)
-        from scipy.signal import hamming
+        from scipy.signal.windows import hamming
         twindow = hamming(int(timelength))
     elif twindow.shape[0] % 2 == 0:
         raise ValueError('The smoothing fwindow must have an odd length.')


### PR DESCRIPTION
Hello,
I am sending minor corrections that are required when using higher versions of the scipy library.
I also noticed problems with the types of variables: the index variable 'lh' (float -> int, fix by: integer division) and 'hlength' hamming window (float -> int, fix: explicit integer casting).

#### Environment
python 3.11
numpy 1.26.4
scipy 1.14.1
matplotlib 3.9.2

Best regards
Eve